### PR TITLE
Correctly export stores as instances instead of types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@capitec/omni-state",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Simple web app state and storage management",
 	"author": "Capitec",
 	"license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@
 export { stateExperimental } from './decorators/stateExperimental.js';
 
 // Stores
-export type { LocalStorage } from './stores/LocalStorage.js';
-export type { SessionStorage } from './stores/SessionStorage.js';
+export { LocalStorage } from './stores/LocalStorage.js';
+export { SessionStorage } from './stores/SessionStorage.js';
 
 // Types
 export type { AsyncStorage } from './types/AsyncStorage.js';


### PR DESCRIPTION
Stores are currently only exported as types, this fixes the export to expose the modules correctly.